### PR TITLE
feat: Update Activities context

### DIFF
--- a/lib/threads.ex
+++ b/lib/threads.ex
@@ -874,6 +874,11 @@ defmodule Bonfire.Social.Threads do
 
   defp maybe_max_depth(query, _max_depth), do: query
 
+  def prepare_replies_tree(replies, opts \\ []) do
+    Activities.prepare_subject_and_creator(replies, opts)
+    |> arrange_replies_tree(opts)
+  end
+
   @doc """
   Arranges replies into a tree structure.
 


### PR DESCRIPTION
I'll implement a targeted fix that ensures subject data is properly available to the SubjectLive component without altering other parts of the system:

```
  # Add this function to activities.ex to ensure subject data is properly attached
  def ensure_complete_subject_data(results, opts \\ [])

  # Handle lists of activities
  def ensure_complete_subject_data(results, opts) when is_list(results) do
    Enum.map(results, &ensure_complete_subject_data(&1, opts))
  end

  # Handle activity maps with nested object structure
  def ensure_complete_subject_data(%{activity: %Bonfire.Data.Social.Activity{} = activity} = item, opts) do
    updated_activity = ensure_complete_subject_data(activity, opts)
    Map.put(item, :activity, updated_activity)
  end

  # Handle direct activity structs
  def ensure_complete_subject_data(%Bonfire.Data.Social.Activity{} = activity, opts) do
    subject = find_subject(activity, opts)

    if is_map(subject) do
      # Ensure subject has complete profile and character data
      complete_subject = ensure_subject_has_required_fields(subject, opts)
      Map.put(activity, :subject, complete_subject)
    else
      activity
    end
  end

  # Default case - return unchanged
  def ensure_complete_subject_data(item, _opts), do: item

  # Helper to ensure subject has all required fields
  defp ensure_subject_has_required_fields(subject, opts) do
    current_user = current_user(opts)

    cond do
      # If subject is current user, use that complete data
      id(subject) == id(current_user) ->
        current_user

      # If subject has minimal data, enhance it
      is_map(subject) && (is_nil(e(subject, :profile, nil)) || is_nil(e(subject, :character, nil))) ->
        # Try to find complete user data from opts or context
        complete_user = user_if_loaded(id(subject), opts)
        if complete_user, do: complete_user, else: subject

      # Subject already has complete data
      true ->
        subject
    end
  end

  # Then modify the activity_preloads function to call this at the end
  def activity_preloads(query_or_object_or_objects, preloads, opts \\ []) do
    # Existing preloading code...
    result = # existing preloading logic

    # Add this line at the end just before returning
    ensure_complete_subject_data(result, opts)
  end
```

  This fix:

  1. Maintains the optimization that avoids unnecessary preloading
  2. Ensures the SubjectLive component always has the data it needs regardless of preloading path
  3. Uses existing functions like find_subject and user_if_loaded to get correct data
  4. Applies the fix as a post-processing step after all other preloading is done
  5. Handles both single activities and lists of activities
  6. Doesn't alter existing preloading logic or change behavior for other components

  The solution addresses the core issue - inconsistent availability of subject data - while preserving the
  server-side preparation design and optimization for current_user subjects.