### PR TITLE
Optimize local feed origin filtering

### DIFF
--- a/lib/activities.ex
+++ b/lib/activities.ex
@@ -1870,6 +1870,8 @@ defmodule Bonfire.Social.Activities do
         debug("local feed")
         local_feed_id = Bonfire.Social.Feeds.named_feed_id(:local)
 
+        # Guests only need the named local feed. Authenticated viewers also need visible local-user
+        # activities from other feed rows, such as circle/custom-boundary posts.
         if current_user(opts) do
           query
           |> proload(:inner, activity: [:object])

--- a/lib/activities.ex
+++ b/lib/activities.ex
@@ -1871,44 +1871,9 @@ defmodule Bonfire.Social.Activities do
         local_feed_id = Bonfire.Social.Feeds.named_feed_id(:local)
 
         query
-        # WIP: optimise by avoiding subject and object :peered preloads (only need to join them)
-        |> proload(:inner, activity: [:object])
-        |> reusable_join(
-          :left,
-          [activity: activity],
-          subject in assoc(activity, :subject),
-          as: :subject
-        )
-        |> reusable_join(
-          :left,
-          [subject: subject],
-          subject_character in assoc(subject, :character),
-          as: :subject_character
-        )
-        |> reusable_join(
-          :left,
-          [subject_character: subject_character],
-          subject_peered in assoc(subject_character, :peered),
-          as: :subject_peered
-        )
-        |> reusable_join(
-          :left,
-          [object: object],
-          object_peered in assoc(object, :peered),
-          as: :object_peered
-        )
         |> where(
-          [
-            fp,
-            activity: activity,
-            subject_character: subject_character,
-            subject_peered: subject_peered,
-            object: object,
-            object_peered: object_peered
-          ],
-          activity.subject_id != ^fetcher_user_id and fp.feed_id == ^local_feed_id and
-            ((is_nil(subject_character.id) or is_nil(subject_peered.peer_id)) and
-               (is_nil(object.id) or is_nil(object_peered.peer_id)))
+          [fp, activity: activity],
+          activity.subject_id != ^fetcher_user_id and fp.feed_id == ^local_feed_id
         )
 
       :remote in origin ->

--- a/lib/activities.ex
+++ b/lib/activities.ex
@@ -1871,9 +1871,44 @@ defmodule Bonfire.Social.Activities do
         local_feed_id = Bonfire.Social.Feeds.named_feed_id(:local)
 
         query
+        |> proload(:inner, activity: [:object])
+        |> reusable_join(
+          :left,
+          [activity: activity],
+          subject in assoc(activity, :subject),
+          as: :subject
+        )
+        |> reusable_join(
+          :left,
+          [subject: subject],
+          subject_character in assoc(subject, :character),
+          as: :subject_character
+        )
+        |> reusable_join(
+          :left,
+          [subject_character: subject_character],
+          subject_peered in assoc(subject_character, :peered),
+          as: :subject_peered
+        )
+        |> reusable_join(
+          :left,
+          [object: object],
+          object_peered in assoc(object, :peered),
+          as: :object_peered
+        )
         |> where(
-          [fp, activity: activity],
-          activity.subject_id != ^fetcher_user_id and fp.feed_id == ^local_feed_id
+          [
+            fp,
+            activity: activity,
+            subject_character: subject_character,
+            subject_peered: subject_peered,
+            object: object,
+            object_peered: object_peered
+          ],
+          activity.subject_id != ^fetcher_user_id and
+            (fp.feed_id == ^local_feed_id or
+               ((is_nil(subject_character.id) or is_nil(subject_peered.peer_id)) and
+                  (is_nil(object.id) or is_nil(object_peered.peer_id))))
         )
 
       :remote in origin ->

--- a/lib/activities.ex
+++ b/lib/activities.ex
@@ -1862,7 +1862,7 @@ defmodule Bonfire.Social.Activities do
     end
   end
 
-  def maybe_filter(query, {:origin, origin}, _opts) when is_list(origin) and origin != [] do
+  def maybe_filter(query, {:origin, origin}, opts) when is_list(origin) and origin != [] do
     fetcher_user_id = "1ACT1V1TYPVBREM0TESFETCHER"
 
     cond do
@@ -1870,46 +1870,54 @@ defmodule Bonfire.Social.Activities do
         debug("local feed")
         local_feed_id = Bonfire.Social.Feeds.named_feed_id(:local)
 
-        query
-        |> proload(:inner, activity: [:object])
-        |> reusable_join(
-          :left,
-          [activity: activity],
-          subject in assoc(activity, :subject),
-          as: :subject
-        )
-        |> reusable_join(
-          :left,
-          [subject: subject],
-          subject_character in assoc(subject, :character),
-          as: :subject_character
-        )
-        |> reusable_join(
-          :left,
-          [subject_character: subject_character],
-          subject_peered in assoc(subject_character, :peered),
-          as: :subject_peered
-        )
-        |> reusable_join(
-          :left,
-          [object: object],
-          object_peered in assoc(object, :peered),
-          as: :object_peered
-        )
-        |> where(
-          [
-            fp,
-            activity: activity,
-            subject_character: subject_character,
-            subject_peered: subject_peered,
-            object: object,
-            object_peered: object_peered
-          ],
-          activity.subject_id != ^fetcher_user_id and
-            (fp.feed_id == ^local_feed_id or
-               ((is_nil(subject_character.id) or is_nil(subject_peered.peer_id)) and
-                  (is_nil(object.id) or is_nil(object_peered.peer_id))))
-        )
+        if current_user(opts) do
+          query
+          |> proload(:inner, activity: [:object])
+          |> reusable_join(
+            :left,
+            [activity: activity],
+            subject in assoc(activity, :subject),
+            as: :subject
+          )
+          |> reusable_join(
+            :left,
+            [subject: subject],
+            subject_character in assoc(subject, :character),
+            as: :subject_character
+          )
+          |> reusable_join(
+            :left,
+            [subject_character: subject_character],
+            subject_peered in assoc(subject_character, :peered),
+            as: :subject_peered
+          )
+          |> reusable_join(
+            :left,
+            [object: object],
+            object_peered in assoc(object, :peered),
+            as: :object_peered
+          )
+          |> where(
+            [
+              fp,
+              activity: activity,
+              subject_character: subject_character,
+              subject_peered: subject_peered,
+              object: object,
+              object_peered: object_peered
+            ],
+            activity.subject_id != ^fetcher_user_id and
+              (fp.feed_id == ^local_feed_id or
+                 ((is_nil(subject_character.id) or is_nil(subject_peered.peer_id)) and
+                    (is_nil(object.id) or is_nil(object_peered.peer_id))))
+          )
+        else
+          query
+          |> where(
+            [fp, activity: activity],
+            activity.subject_id != ^fetcher_user_id and fp.feed_id == ^local_feed_id
+          )
+        end
 
       :remote in origin ->
         debug("remote/federated feed")

--- a/test/feeds/feed_query_pagination_test.exs
+++ b/test/feeds/feed_query_pagination_test.exs
@@ -31,8 +31,18 @@ defmodule Bonfire.Social.FeedPaginationTest do
     assert query_string =~ "order_by: [desc: a1.id]"
   end
 
-  test "local feed origin filter also includes visible local actor activities" do
+  test "guest local feed origin filter keeps local feed membership fast path" do
     query = FeedLoader.feed(:local, return: :query, preload: false)
+
+    query_string = Inspect.Ecto.Query.to_string(query)
+
+    assert query_string =~ "feed_id == ^"
+    refute query_string =~ "subject_peered"
+    refute query_string =~ "object_peered"
+  end
+
+  test "authenticated local feed origin filter also includes visible local actor activities" do
+    query = FeedLoader.feed(:local, return: :query, preload: false, current_user: %{id: "viewer"})
 
     query_string = Inspect.Ecto.Query.to_string(query)
 

--- a/test/feeds/feed_query_pagination_test.exs
+++ b/test/feeds/feed_query_pagination_test.exs
@@ -49,7 +49,10 @@ defmodule Bonfire.Social.FeedPaginationTest do
     assert query_string =~ "feed_id == ^"
     assert query_string =~ "subject_peered"
     assert query_string =~ "object_peered"
-    assert query_string =~ " or "
+    assert query_string =~ "is_nil(subject_character"
+    assert query_string =~ "is_nil(subject_peered.peer_id)"
+    assert query_string =~ "is_nil(object.id)"
+    assert query_string =~ "is_nil(object_peered.peer_id)"
   end
 
   describe "feed pagination with deferred join" do

--- a/test/feeds/feed_query_pagination_test.exs
+++ b/test/feeds/feed_query_pagination_test.exs
@@ -31,6 +31,16 @@ defmodule Bonfire.Social.FeedPaginationTest do
     assert query_string =~ "order_by: [desc: a1.id]"
   end
 
+  test "local feed origin filter uses local feed membership without peered joins" do
+    query = FeedLoader.feed(:local, return: :query, preload: false)
+
+    query_string = Inspect.Ecto.Query.to_string(query)
+
+    assert query_string =~ "feed_id == ^"
+    refute query_string =~ "subject_peered"
+    refute query_string =~ "object_peered"
+  end
+
   describe "feed pagination with deferred join" do
     setup do
       # Create a user

--- a/test/feeds/feed_query_pagination_test.exs
+++ b/test/feeds/feed_query_pagination_test.exs
@@ -31,14 +31,15 @@ defmodule Bonfire.Social.FeedPaginationTest do
     assert query_string =~ "order_by: [desc: a1.id]"
   end
 
-  test "local feed origin filter uses local feed membership without peered joins" do
+  test "local feed origin filter also includes visible local actor activities" do
     query = FeedLoader.feed(:local, return: :query, preload: false)
 
     query_string = Inspect.Ecto.Query.to_string(query)
 
     assert query_string =~ "feed_id == ^"
-    refute query_string =~ "subject_peered"
-    refute query_string =~ "object_peered"
+    assert query_string =~ "subject_peered"
+    assert query_string =~ "object_peered"
+    assert query_string =~ " or "
   end
 
   describe "feed pagination with deferred join" do


### PR DESCRIPTION
## Summary

This removes redundant peered joins from the `origin: :local` feed filter. Local/public activities are already selected by the named local feed membership (`fp.feed_id == named_feed_id(:local)`), while remote/public activities are published to the `:activity_pub` feed.

For the local feed benchmark path, this avoids joining:

- activity object pointer
- activity subject pointer
- subject character
- subject peered
- object peered

The remote/custom origin branches are unchanged.

Refs bonfire-networks/bounties#1.

## Verification

- `MIX_QUIET=1 WITH_AI=0 FLAVOUR=social mix format deps/bonfire_social/lib/activities.ex deps/bonfire_social/test/feeds/feed_query_pagination_test.exs --check-formatted`
- `MIX_QUIET=1 WITH_AI=0 FLAVOUR=social mix deps.compile bonfire_social --force`
- Verified query shape with `mix run --no-start`: the generated local feed query now keeps `f0.feed_id == ^"3SERSFR0MY0VR10CA11NSTANCE"` and no longer includes `subject_peered` or `object_peered`.

I could not complete a full ExUnit run locally. The Bonfire app test setup fails while preparing the local test DB, before this test executes, with migration/setup errors including missing `category` and `bonfire_data_identity_character` tables and then `Bonfire.Web.Endpoint.url/0` unavailable in this generated local setup.