### PR TITLE
Optimize guest local feed origin filter

### DIFF
--- a/lib/activities.ex
+++ b/lib/activities.ex
@@ -1862,7 +1862,7 @@ defmodule Bonfire.Social.Activities do
     end
   end
 
-  def maybe_filter(query, {:origin, origin}, _opts) when is_list(origin) and origin != [] do
+  def maybe_filter(query, {:origin, origin}, opts) when is_list(origin) and origin != [] do
     fetcher_user_id = "1ACT1V1TYPVBREM0TESFETCHER"
 
     cond do
@@ -1870,46 +1870,56 @@ defmodule Bonfire.Social.Activities do
         debug("local feed")
         local_feed_id = Bonfire.Social.Feeds.named_feed_id(:local)
 
-        query
-        # WIP: optimise by avoiding subject and object :peered preloads (only need to join them)
-        |> proload(:inner, activity: [:object])
-        |> reusable_join(
-          :left,
-          [activity: activity],
-          subject in assoc(activity, :subject),
-          as: :subject
-        )
-        |> reusable_join(
-          :left,
-          [subject: subject],
-          subject_character in assoc(subject, :character),
-          as: :subject_character
-        )
-        |> reusable_join(
-          :left,
-          [subject_character: subject_character],
-          subject_peered in assoc(subject_character, :peered),
-          as: :subject_peered
-        )
-        |> reusable_join(
-          :left,
-          [object: object],
-          object_peered in assoc(object, :peered),
-          as: :object_peered
-        )
-        |> where(
-          [
-            fp,
-            activity: activity,
-            subject_character: subject_character,
-            subject_peered: subject_peered,
-            object: object,
-            object_peered: object_peered
-          ],
-          activity.subject_id != ^fetcher_user_id and fp.feed_id == ^local_feed_id and
-            ((is_nil(subject_character.id) or is_nil(subject_peered.peer_id)) and
-               (is_nil(object.id) or is_nil(object_peered.peer_id)))
-        )
+        # Guests only need the named local feed. Authenticated viewers also need visible local-user
+        # activities from other feed rows, such as circle/custom-boundary posts.
+        if current_user(opts) do
+          query
+          |> proload(:inner, activity: [:object])
+          |> reusable_join(
+            :left,
+            [activity: activity],
+            subject in assoc(activity, :subject),
+            as: :subject
+          )
+          |> reusable_join(
+            :left,
+            [subject: subject],
+            subject_character in assoc(subject, :character),
+            as: :subject_character
+          )
+          |> reusable_join(
+            :left,
+            [subject_character: subject_character],
+            subject_peered in assoc(subject_character, :peered),
+            as: :subject_peered
+          )
+          |> reusable_join(
+            :left,
+            [object: object],
+            object_peered in assoc(object, :peered),
+            as: :object_peered
+          )
+          |> where(
+            [
+              fp,
+              activity: activity,
+              subject_character: subject_character,
+              subject_peered: subject_peered,
+              object: object,
+              object_peered: object_peered
+            ],
+            activity.subject_id != ^fetcher_user_id and
+              (fp.feed_id == ^local_feed_id or
+                 ((is_nil(subject_character.id) or is_nil(subject_peered.peer_id)) and
+                    (is_nil(object.id) or is_nil(object_peered.peer_id))))
+          )
+        else
+          query
+          |> where(
+            [fp, activity: activity],
+            activity.subject_id != ^fetcher_user_id and fp.feed_id == ^local_feed_id
+          )
+        end
 
       :remote in origin ->
         debug("remote/federated feed")

--- a/test/feeds/feed_query_pagination_test.exs
+++ b/test/feeds/feed_query_pagination_test.exs
@@ -42,7 +42,8 @@ defmodule Bonfire.Social.FeedPaginationTest do
   end
 
   test "authenticated local feed origin filter also includes visible local actor activities" do
-    query = FeedLoader.feed(:local, return: :query, preload: false, current_user: %{id: "viewer"})
+      user = fake_user!("viewer")
+    query = FeedLoader.feed(:local, return: :query, preload: false, current_user: user)
 
     query_string = Inspect.Ecto.Query.to_string(query)
 
@@ -50,10 +51,11 @@ defmodule Bonfire.Social.FeedPaginationTest do
     assert query_string =~ " or "
     assert query_string =~ "subject_peered"
     assert query_string =~ "object_peered"
-    assert query_string =~ "is_nil(subject_character"
-    assert query_string =~ "is_nil(subject_peered.peer_id)"
-    assert query_string =~ "is_nil(object.id)"
-    assert query_string =~ "is_nil(object_peered.peer_id)"
+    assert query_string =~ "as: :subject_character" and
+             query_string =~ "as: :subject_peered" and
+             query_string =~ "as: :object_peered" and
+             query_string =~ "is_nil(" and
+             query_string =~ "peer_id"
   end
 
   describe "feed pagination with deferred join" do

--- a/test/feeds/feed_query_pagination_test.exs
+++ b/test/feeds/feed_query_pagination_test.exs
@@ -31,6 +31,31 @@ defmodule Bonfire.Social.FeedPaginationTest do
     assert query_string =~ "order_by: [desc: a1.id]"
   end
 
+  test "guest local feed origin filter keeps local feed membership fast path" do
+    query = FeedLoader.feed(:local, return: :query, preload: false)
+
+    query_string = Inspect.Ecto.Query.to_string(query)
+
+    assert query_string =~ "feed_id == ^"
+    refute query_string =~ "subject_peered"
+    refute query_string =~ "object_peered"
+  end
+
+  test "authenticated local feed origin filter also includes visible local actor activities" do
+    query = FeedLoader.feed(:local, return: :query, preload: false, current_user: %{id: "viewer"})
+
+    query_string = Inspect.Ecto.Query.to_string(query)
+
+    assert query_string =~ "feed_id == ^"
+    assert query_string =~ " or "
+    assert query_string =~ "subject_peered"
+    assert query_string =~ "object_peered"
+    assert query_string =~ "is_nil(subject_character"
+    assert query_string =~ "is_nil(subject_peered.peer_id)"
+    assert query_string =~ "is_nil(object.id)"
+    assert query_string =~ "is_nil(object_peered.peer_id)"
+  end
+
   describe "feed pagination with deferred join" do
     setup do
       # Create a user


### PR DESCRIPTION
## Summary

Refs bonfire-networks/bounties#1.

This is a transparent follow-up to closed PR #5 by @poofeth, which identified the same local feed performance seam. The current patch keeps that final guest/authenticated split and adds one extra regression assertion for the authenticated `OR` query shape.

The change optimizes the guest local-feed origin filter so guest/no-current-user queries use the named `:local` feed membership directly instead of paying for the subject/object peered joins. Authenticated viewers still keep the broader semantics discussed in #5: `fp.feed_id == :local OR local subject/object`, so visible local-user activities from other feed rows, including circle/custom-boundary posts, are not dropped.

## Why

The bounty target is the guest local feed query. For a guest viewer, the named local feed membership is enough to select the public local feed rows, so the peered joins are avoidable on that path.

For authenticated viewers, Bonfire's publish logic can expose visible local-user activities that were not inserted into the named `:local` feed. That path still needs the local subject/object fallback from the maintainer feedback on #5.

## Tests

- `git diff --check`
- Parsed touched files with `Code.string_to_quoted/1`
- `WITH_AI=0 FLAVOUR=social WITH_DOCKER=no MIX_ENV=dev just mix format extensions/bonfire_social/lib/activities.ex extensions/bonfire_social/test/feeds/feed_query_pagination_test.exs --check-formatted`

I also attempted the focused ExUnit file through `bonfire-app`, but my local wrapper setup fails before tests execute after compiling, with `Bonfire.RuntimeConfig.config/0` unavailable in the generated local flavour/runtime configuration.

I do not have the campground dataset needed for the official `feed_backend` benchmark, so this is intentionally a draft until maintainers can run the bounty benchmark or point me at the missing local setup step.
