### PR TITLE
perf: bound local feed pagination queries

### DIFF
--- a/lib/feed_loader.ex
+++ b/lib/feed_loader.ex
@@ -17,6 +17,10 @@ defmodule Bonfire.Social.FeedLoader do
   alias Bonfire.Common.DatesTimes
   alias Bonfire.Common.Enums
   alias Bonfire.Common.Types
+  alias Bonfire.Boundaries.Circles
+  alias Bonfire.Boundaries.Verbs
+  alias Bonfire.Data.AccessControl.Controlled
+  alias Bonfire.Data.AccessControl.Grant
   alias Bonfire.Data.Social.Activity
   alias Bonfire.Data.Social.Message
   alias Bonfire.Data.Social.Seen
@@ -33,6 +37,11 @@ defmodule Bonfire.Social.FeedLoader do
   @like_verb_id "11KES1ND1CATEAM11DAPPR0VA1"
   @boost_verb_id "300ST0R0RANN0VCEANACT1V1TY"
   @reply_verb_id "71TCREAT1NGA11NKEDRESP0NSE"
+  @minimum_deferred_join_multiply_limit 6
+  @refill_deferred_join_multiply_limit 32
+  @max_refill_deferred_join_multiply_limit 256
+  @local_max_refill_deferred_join_multiply_limit 512
+  @guest_visible_acl_verbs [:see, :read]
 
   # ==== START OF CODE TO REFACTOR ====
   def prepare_feed_filters(preset \\ nil, feed_name, opts) do
@@ -497,18 +506,23 @@ defmodule Bonfire.Social.FeedLoader do
   """
   def feed_many_paginated(query, filters, opts) do
     opts = prepare_opts_for_pagination(query, filters, opts)
-    query |> repo().many_maybe_paginated(opts[:paginate] || opts, opts)
+    query |> repo().many_maybe_paginated(pagination_arg(opts), opts)
   end
 
   defp prepare_opts_for_pagination(query, filters, opts) do
     opts = to_options(opts)
 
-    deferred_join_multiply_limit = opts[:deferred_join_multiply_limit]
-
-    if is_integer(deferred_join_multiply_limit) and
-         deferred_join_multiply_limit > 1 do
-      paginate_and_boundarise_feed_deferred_multiplied_opts(deferred_join_multiply_limit, opts)
-      |> info("paginate the deferred join window from the get-go")
+    if is_integer(opts[:deferred_join_multiply_limit]) and
+         opts[:deferred_join_multiply_limit] > 1 do
+      if cursor_pagination?(opts) do
+        opts
+      else
+        paginate_and_boundarise_feed_deferred_multiplied_opts(
+          opts[:deferred_join_multiply_limit],
+          opts
+        )
+        |> info("paginate the deferred join window from the get-go")
+      end
     else
       opts
     end
@@ -516,6 +530,10 @@ defmodule Bonfire.Social.FeedLoader do
       Activities.order_pagination_opts(filters[:sort_by], filters[:sort_order], opts)
     )
     |> debug("prepared opts for pagination")
+  end
+
+  defp pagination_arg(opts) do
+    if Keyword.get(opts, :paginate) == false, do: false, else: opts
   end
 
   @decorate time()
@@ -586,18 +604,16 @@ defmodule Bonfire.Social.FeedLoader do
 
         with %Ecto.Query{} = deferred_query <-
                maybe_prepare_per_media_query(query, filters, opts) ||
-                 maybe_prepare_and_boundarise_feed_deferred_query(query, filters, opts),
-             %{edges: []} when per_media? != true <-
-               deferred_query |> repo().many_maybe_paginated(opts[:paginate] || opts, opts) do
-          debug("empty results in deferred join, trying pagination to next window")
-          # WIP: Try paginating to the next window of results if the initial one is empty
-          paginate_and_boundarise_feed_deferred_fallback(query, filters, opts)
+                 maybe_prepare_and_boundarise_feed_deferred_query(query, filters, opts) do
+          deferred_query
+          |> repo().many_maybe_paginated(pagination_arg(opts), opts)
+          |> maybe_refill_deferred_page(query, filters, opts, per_media?)
         else
           nil ->
             debug("deferred join is not enabled")
 
             paginate_and_boundarise_feed_non_deferred_query(query, filters, opts)
-            |> repo().many_maybe_paginated(opts[:paginate] || opts, opts)
+            |> repo().many_maybe_paginated(pagination_arg(opts), opts)
 
           %Ecto.Query{} = query ->
             query
@@ -617,30 +633,7 @@ defmodule Bonfire.Social.FeedLoader do
       if Enum.any?(query.joins, &(&1.as == :deferred_join_subquery)),
         do: throw("Feed query already deferred")
 
-      initial_query =
-        query
-        # |> debug()
-        |> apply_dedup_strategy(filters, opts)
-        # # WIP: For show_objects_only_once apply dedup on the outer query; inner uses normal activity.id distinct
-        # |> then(
-        #   if filters[:show_objects_only_once] != false and not filters[:dedup_by_thread],
-        #     do: &make_distinct_by_activity_id(&1, filters[:sort_by], filters[:sort_order], opts),
-        #     else: &apply_dedup_strategy(&1, filters, opts)
-        # )
-        |> FeedActivities.query_order(
-          filters[:sort_by],
-          filters[:sort_order],
-          :id,
-          opts[:with_pins?]
-        )
-        |> repo().build_deferred_inner_subquery(
-          filters,
-          Keyword.put(
-            opts,
-            :deferred_join_multiply_limit,
-            max(opts[:deferred_join_multiply_limit] || 2, 6)
-          )
-        )
+      initial_query = build_deferred_inner_query(query, filters, opts)
 
       # |> debug("deferred subquery")
 
@@ -666,6 +659,222 @@ defmodule Bonfire.Social.FeedLoader do
       |> Activities.as_permitted_for(opts)
       |> debug("query with deferred join")
     end
+  end
+
+  defp build_deferred_inner_query(query, filters, opts) do
+    query
+    # |> debug()
+    |> apply_dedup_strategy(filters, opts)
+    |> apply_deferred_id_cursor_filter(opts)
+    |> maybe_apply_deferred_inner_guest_visible_acl_filter(opts)
+    |> maybe_apply_deferred_inner_boundary_filter(opts)
+    # # WIP: For show_objects_only_once apply dedup on the outer query; inner uses normal activity.id distinct
+    # |> then(
+    #   if filters[:show_objects_only_once] != false and not filters[:dedup_by_thread],
+    #     do: &make_distinct_by_activity_id(&1, filters[:sort_by], filters[:sort_order], opts),
+    #     else: &apply_dedup_strategy(&1, filters, opts)
+    # )
+    |> query_order_deferred_inner(filters, opts)
+    |> repo().build_deferred_inner_subquery(filters, deferred_inner_pagination_opts(opts))
+  end
+
+  defp deferred_inner_pagination_opts(opts) do
+    opts
+    |> deferred_join_query_opts(opts[:deferred_join_multiply_limit])
+    |> maybe_drop_deferred_inner_paginator_cursor()
+  end
+
+  defp maybe_apply_deferred_inner_guest_visible_acl_filter(query, opts) do
+    with true <- opts[:deferred_inner_guest_visible_acl_filter],
+         %Ecto.Query{} = guest_visible_ids <-
+           guest_visible_acl_object_ids_query(deferred_guest_visible_acl_candidate_limit(opts)) do
+      join(query, :inner, [main_object: fp], guest_visible_id in subquery(guest_visible_ids),
+        on: guest_visible_id.id == fp.id,
+        as: :deferred_inner_guest_visible_acl
+      )
+    else
+      _ -> query
+    end
+  end
+
+  defp guest_visible_acl_object_ids_query(candidate_limit) do
+    with {guest_id, verb_ids} <- guest_visible_acl_scope() do
+      from(controlled in Controlled,
+        join: grant in Grant,
+        on: grant.acl_id == controlled.acl_id,
+        where: grant.subject_id == ^guest_id,
+        where: grant.verb_id in ^verb_ids,
+        where: grant.value == true,
+        distinct: [desc: controlled.id],
+        order_by: [desc: controlled.id],
+        limit: ^candidate_limit,
+        select: %{id: controlled.id}
+      )
+    end
+  end
+
+  defp guest_visible_acl_scope do
+    with guest_id when is_binary(guest_id) <- Circles.get_id(:guest),
+         [_ | _] = verb_ids <- Verbs.ids(@guest_visible_acl_verbs) do
+      {guest_id, verb_ids}
+    else
+      _ -> nil
+    end
+  end
+
+  defp guest_visible_acl_scope? do
+    match?({_guest_id, [_ | _]}, guest_visible_acl_scope())
+  end
+
+  defp deferred_guest_visible_acl_candidate_limit(opts) do
+    opts
+    |> deferred_join_query_opts(opts[:deferred_join_multiply_limit])
+    |> Keyword.fetch!(:maximum_limit)
+  end
+
+  defp maybe_apply_deferred_inner_boundary_filter(query, opts) do
+    if opts[:deferred_inner_boundary_filter] do
+      Activities.as_permitted_for(query, opts)
+    else
+      query
+    end
+  end
+
+  defp query_order_deferred_inner(query, filters, opts) do
+    case deferred_inner_ordering(query, filters, opts) do
+      {:guest_visible_acl, direction} ->
+        order_deferred_inner_guest_visible_acl(query, direction)
+
+      {:feed_publish, direction} ->
+        order_deferred_inner_feed_publish(query, direction)
+
+      :activity ->
+        FeedActivities.query_order(
+          query,
+          filters[:sort_by],
+          filters[:sort_order],
+          :id,
+          opts[:with_pins?]
+        )
+    end
+  end
+
+  defp deferred_inner_ordering(query, filters, opts) do
+    sort_by = filters[:sort_by] || opts[:sort_by]
+
+    cond do
+      opts[:with_pins?] == true or not is_nil(sort_by) ->
+        :activity
+
+      opts[:deferred_inner_guest_visible_acl_filter] == true and
+          Ecto.Query.has_named_binding?(query, :deferred_inner_guest_visible_acl) ->
+        {:guest_visible_acl, sort_direction(filters, opts)}
+
+      opts[:deferred_inner_order] == :feed_publish_id ->
+        {:feed_publish, sort_direction(filters, opts)}
+
+      true ->
+        :activity
+    end
+  end
+
+  defp sort_direction(filters, opts) do
+    case filters[:sort_order] || opts[:sort_order] || :desc do
+      :asc -> :asc
+      _ -> :desc
+    end
+  end
+
+  defp order_deferred_inner_guest_visible_acl(query, :asc) do
+    order_by(
+      query,
+      [deferred_inner_guest_visible_acl: guest_visible_id],
+      asc: guest_visible_id.id
+    )
+  end
+
+  defp order_deferred_inner_guest_visible_acl(query, _desc) do
+    order_by(
+      query,
+      [deferred_inner_guest_visible_acl: guest_visible_id],
+      desc: guest_visible_id.id
+    )
+  end
+
+  defp order_deferred_inner_feed_publish(query, :asc) do
+    order_by(query, [main_object: fp], asc: fp.id)
+  end
+
+  defp order_deferred_inner_feed_publish(query, _desc) do
+    order_by(query, [main_object: fp], desc: fp.id)
+  end
+
+  defp maybe_drop_deferred_inner_paginator_cursor(opts) do
+    # The inner feed_publish window already has a plain cursor predicate; keeping
+    # Paginator's nullable cursor predicate there prevents an index-bounded scan.
+    if opts[:deferred_inner_order] == :feed_publish_id and
+         (decoded_id_cursor(opts[:after]) || decoded_id_cursor(opts[:before])) do
+      opts
+      |> Keyword.delete(:after)
+      |> Keyword.delete(:before)
+    else
+      opts
+    end
+  end
+
+  defp apply_deferred_id_cursor_filter(query, opts) do
+    opts = repo().pagination_opts(opts)
+
+    case {Keyword.get(opts, :after), Keyword.get(opts, :before),
+          Keyword.get(opts, :cursor_fields)} do
+      {cursor, nil, [{:id, :desc}]} ->
+        maybe_filter_deferred_id_cursor(query, cursor, :lt)
+
+      {nil, cursor, [{:id, :desc}]} ->
+        maybe_filter_deferred_id_cursor(query, cursor, :gt)
+
+      {cursor, nil, [{:id, :asc}]} ->
+        maybe_filter_deferred_id_cursor(query, cursor, :gt)
+
+      {nil, cursor, [{:id, :asc}]} ->
+        maybe_filter_deferred_id_cursor(query, cursor, :lt)
+
+      _ ->
+        query
+    end
+  end
+
+  defp maybe_filter_deferred_id_cursor(query, cursor, direction) do
+    case decoded_id_cursor(cursor) do
+      nil -> query
+      id -> filter_deferred_id_cursor(query, id, direction)
+    end
+  end
+
+  defp decoded_id_cursor(cursor) when is_binary(cursor) do
+    with %{id: id} <- Paginator.Cursor.maybe_decode(cursor),
+         true <- raw_uuid_cursor?(id) do
+      id
+    else
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp decoded_id_cursor(_), do: nil
+
+  defp raw_uuid_cursor?(cursor) when is_binary(cursor),
+    do: match?({:ok, _}, Ecto.UUID.cast(cursor))
+
+  defp raw_uuid_cursor?(_), do: false
+
+  defp filter_deferred_id_cursor(query, cursor, :lt) do
+    where(query, [main_object: fp], fp.id < ^cursor)
+  end
+
+  defp filter_deferred_id_cursor(query, cursor, :gt) do
+    where(query, [main_object: fp], fp.id > ^cursor)
   end
 
   defp maybe_prepare_per_media_query(initial_query, filters, opts) do
@@ -736,67 +945,251 @@ defmodule Bonfire.Social.FeedLoader do
          deferred_join_multiply_limit,
          opts
        ) do
-    # Create new pagination options with the cursor from the empty result
-    deferred_join_multiply_limit =
-      case deferred_join_multiply_limit do
-        0 -> 2
-        limit when is_integer(limit) -> limit
-        _ -> 2
-      end
+    previous_deferred_join_multiply_limit =
+      previous_deferred_join_multiply_limit ||
+        max(div(deferred_join_multiply_limit, 2), 2)
 
     Keyword.merge(
       repo().pagination_opts(opts),
       [
-        # after: after_cursor,
-        # Increase the limit to fetch more results
         deferred_join_multiply_limit: deferred_join_multiply_limit,
-        # Change the pagination offset to match - FIXME: shouldn't this use the previous limit?
         deferred_join_offset:
-          (previous_deferred_join_multiply_limit || 2) *
-            (opts[:limit] || Bonfire.Common.Config.get(:default_pagination_limit, 10))
+          deferred_join_window_limit(opts, previous_deferred_join_multiply_limit)
       ]
       |> info("Empty results in first join window, attempting pagination to next window")
     )
   end
 
+  defp cursor_pagination?(opts) do
+    opts = repo().pagination_opts(opts)
+    opts[:after] || opts[:before]
+  end
+
+  defp effective_deferred_join_multiply_limit(limit, opts \\ []) do
+    minimum_limit =
+      opts[:minimum_deferred_join_multiply_limit] || @minimum_deferred_join_multiply_limit
+
+    case Types.maybe_to_integer(limit) do
+      nil -> minimum_limit
+      limit -> max(limit, minimum_limit)
+    end
+  end
+
+  defp deferred_join_query_opts(opts, deferred_join_multiply_limit) do
+    multiply_limit = effective_deferred_join_multiply_limit(deferred_join_multiply_limit, opts)
+    page_limit = requested_page_limit(opts)
+    maximum_limit = page_limit * multiply_limit
+
+    opts
+    |> Keyword.put(:deferred_join_multiply_limit, multiply_limit)
+    |> Keyword.update(:maximum_limit, maximum_limit, fn current ->
+      max(Types.maybe_to_integer(current) || maximum_limit, maximum_limit)
+    end)
+  end
+
+  defp deferred_join_window_limit(opts, deferred_join_multiply_limit) do
+    opts
+    |> deferred_join_query_opts(deferred_join_multiply_limit)
+    |> Keyword.put_new(:paginate, true)
+    |> Keyword.put(
+      :multiply_limit,
+      effective_deferred_join_multiply_limit(deferred_join_multiply_limit, opts)
+    )
+    |> repo().pagination_opts()
+    |> Paginator.Config.limit()
+  end
+
   defp paginate_and_boundarise_feed_deferred_fallback(query, filters, opts) do
     # WIP: Try paginating to the next window of results if the initial one is empty
 
-    next_page_opts =
-      if :per_media in List.wrap(opts[:preload]) do
-        # For media aggregation when none where found:
-        # We need to get ALL qualifying activities first, then aggregate by media
-        previous_limit = opts[:per_media_multiply_limit] || 5
+    if :per_media in List.wrap(opts[:preload]) do
+      # For media aggregation when none where found:
+      # We need to get ALL qualifying activities first, then aggregate by media
+      previous_limit = opts[:per_media_multiply_limit] || 5
 
+      next_page_opts =
         opts
         |> Keyword.put(:per_media_multiply_limit, 1000)
         |> Keyword.put(:deferred_join_offset, previous_limit)
         |> debug("unlimited opts for per_media non-deferred query")
-      else
-        previous_deferred_join_multiply_limit = opts[:deferred_join_multiply_limit] || 2
 
-        paginate_and_boundarise_feed_deferred_multiplied_opts(
-          previous_deferred_join_multiply_limit,
-          previous_deferred_join_multiply_limit * 2,
-          opts
+      case retry_deferred_page(query, filters, opts, next_page_opts) do
+        %{edges: []} -> fallback_to_non_deferred_page(query, filters, opts)
+        result -> result
+      end
+    else
+      current_limit =
+        effective_deferred_join_multiply_limit(opts[:deferred_join_multiply_limit], opts)
+
+      do_paginate_and_boundarise_feed_deferred_fallback(
+        query,
+        filters,
+        opts,
+        current_limit,
+        empty_refill_deferred_join_multiply_limit(opts, current_limit)
+      )
+    end
+  end
+
+  defp do_paginate_and_boundarise_feed_deferred_fallback(
+         query,
+         filters,
+         opts,
+         previous_limit,
+         next_limit
+       ) do
+    if next_limit <= max_refill_deferred_join_multiply_limit(opts) do
+      next_page_opts =
+        paginate_and_boundarise_feed_deferred_multiplied_opts(previous_limit, next_limit, opts)
+
+      with %{edges: []} <- retry_deferred_page(query, filters, opts, next_page_opts) do
+        do_paginate_and_boundarise_feed_deferred_fallback(
+          query,
+          filters,
+          opts,
+          next_limit,
+          next_limit * 2
         )
       end
+    else
+      fallback_to_non_deferred_page(query, filters, opts)
+    end
+  end
 
-    # Try the query again with the new cursor
+  defp retry_deferred_page(query, filters, opts, next_page_opts) do
     with %Ecto.Query{} = deferred_query <-
            maybe_prepare_per_media_query(query, filters, next_page_opts) ||
              maybe_prepare_and_boundarise_feed_deferred_query(query, filters, next_page_opts),
-         %{edges: []} <-
-           deferred_query
-           |> repo().many_maybe_paginated(
-             next_page_opts[:paginate] || next_page_opts,
+         result <-
+           repo().many_maybe_paginated(
+             deferred_query,
+             pagination_arg(next_page_opts),
              next_page_opts
            ) do
-      debug("No results in next window either, falling back to non-deferred query")
-
-      paginate_and_boundarise_feed_non_deferred_query(query, filters, opts)
-      |> repo().many_maybe_paginated(opts[:paginate] || opts, opts)
+      result
+    else
+      _ -> fallback_to_non_deferred_page(query, filters, opts)
     end
+  end
+
+  defp maybe_refill_deferred_page(result, _query, _filters, _opts, true = _per_media?), do: result
+
+  defp maybe_refill_deferred_page(%{edges: []}, query, filters, opts, _per_media?) do
+    debug("empty results in deferred join, trying pagination to next window")
+    paginate_and_boundarise_feed_deferred_fallback(query, filters, opts)
+  end
+
+  defp maybe_refill_deferred_page(%{edges: edges} = result, query, filters, opts, _per_media?)
+       when is_list(edges) do
+    if length(edges) < requested_page_limit(opts) do
+      refill_deferred_page(result, query, filters, opts)
+    else
+      ensure_deferred_page_cursor(result, opts)
+    end
+  end
+
+  defp maybe_refill_deferred_page(result, _query, _filters, _opts, _per_media?), do: result
+
+  defp refill_deferred_page(result, query, filters, opts) do
+    requested_limit = requested_page_limit(opts)
+
+    current_limit =
+      effective_deferred_join_multiply_limit(opts[:deferred_join_multiply_limit], opts)
+
+    refill_limit = underfilled_refill_deferred_join_multiply_limit(opts, current_limit)
+
+    do_refill_deferred_page(refill_limit, requested_limit, result, query, filters, opts)
+  end
+
+  defp do_refill_deferred_page(refill_limit, requested_limit, _result, query, filters, opts) do
+    if refill_limit <= max_refill_deferred_join_multiply_limit(opts) do
+      refill_opts = refill_deferred_join_opts(opts, refill_limit)
+
+      debug(refill_opts, "under-filled deferred join page, retrying with larger window")
+
+      with %Ecto.Query{} = deferred_query <-
+             maybe_prepare_and_boundarise_feed_deferred_query(query, filters, refill_opts),
+           %{edges: edges} = refilled_result <-
+             repo().many_maybe_paginated(deferred_query, pagination_arg(refill_opts), refill_opts),
+           true <- length(edges) >= requested_limit do
+        ensure_deferred_page_cursor(refilled_result, opts)
+      else
+        %{edges: edges} when is_list(edges) ->
+          do_refill_deferred_page(refill_limit * 2, requested_limit, nil, query, filters, opts)
+
+        _ ->
+          fallback_to_non_deferred_page(query, filters, opts)
+      end
+    else
+      fallback_to_non_deferred_page(query, filters, opts)
+    end
+  end
+
+  defp ensure_deferred_page_cursor(
+         %{edges: edges, page_info: %{end_cursor: nil, final_cursor: cursor} = page_info} =
+           result,
+         opts
+       )
+       when is_list(edges) and is_binary(cursor) do
+    pagination_opts = repo().pagination_opts(opts)
+
+    if Keyword.get(pagination_opts, :before) || length(edges) < requested_page_limit(opts) do
+      result
+    else
+      %{result | page_info: %{page_info | end_cursor: cursor, final_cursor: nil}}
+    end
+  end
+
+  defp ensure_deferred_page_cursor(result, _opts), do: result
+
+  defp fallback_to_non_deferred_page(query, filters, opts) do
+    debug("larger deferred join windows still under-filled, falling back to non-deferred query")
+    emit_deferred_join_fallback(opts)
+
+    paginate_and_boundarise_feed_non_deferred_query(query, filters, opts)
+    |> repo().many_maybe_paginated(pagination_arg(opts), opts)
+  end
+
+  defp emit_deferred_join_fallback(opts) do
+    :telemetry.execute(
+      [:bonfire, :social, :feed_loader, :deferred_join, :fallback],
+      %{},
+      %{
+        cursor_pagination?: !!cursor_pagination?(opts),
+        deferred_join_multiply_limit: opts[:deferred_join_multiply_limit],
+        feed_name: opts[:feed_name],
+        preload: opts[:preload]
+      }
+    )
+  end
+
+  defp refill_deferred_join_opts(opts, multiply_limit) do
+    deferred_join_query_opts(opts, multiply_limit)
+  end
+
+  defp max_refill_deferred_join_multiply_limit(opts) do
+    opts[:max_refill_deferred_join_multiply_limit] || @max_refill_deferred_join_multiply_limit
+  end
+
+  defp empty_refill_deferred_join_multiply_limit(opts, current_limit) do
+    max(opts[:empty_refill_deferred_join_multiply_limit] || 0, current_limit * 2)
+  end
+
+  defp underfilled_refill_deferred_join_multiply_limit(opts, current_limit) do
+    max(
+      opts[:underfilled_refill_deferred_join_multiply_limit] ||
+        @refill_deferred_join_multiply_limit,
+      current_limit * 2
+    )
+  end
+
+  defp requested_page_limit(opts) do
+    opts
+    |> Keyword.delete(:multiply_limit)
+    |> Keyword.put_new(:paginate, true)
+    |> repo().pagination_opts()
+    |> Paginator.Config.limit()
+    |> Types.maybe_to_integer()
   end
 
   defp paginate_and_boundarise_feed_non_deferred_query(query, filters, opts) do
@@ -852,8 +1245,7 @@ defmodule Bonfire.Social.FeedLoader do
     #   |> debug("3a. feed options")
 
     if opts[:cache] do
-      # FIXME: key should include filters
-      key = feed_id_or_ids_or_name
+      key = feed_cache_key(feed_id_or_ids_or_name, filters, opts)
 
       case Cache.get!(key) do
         nil ->
@@ -870,6 +1262,30 @@ defmodule Bonfire.Social.FeedLoader do
 
       actually_do_feed(feed_id_or_ids_or_name, filters, opts)
     end
+  end
+
+  defp feed_cache_key(feed_id_or_ids_or_name, filters, opts) do
+    {
+      __MODULE__,
+      :feed,
+      feed_id_or_ids_or_name,
+      filters,
+      Keyword.take(opts, [
+        :after,
+        :before,
+        :limit,
+        :paginate,
+        :preload,
+        :query_with_deferred_join,
+        :show_objects_only_once,
+        :skip_boundary_check,
+        :sort_by,
+        :sort_order,
+        :time_limit
+      ]),
+      Enums.id(current_user(opts)),
+      Enums.id(current_account(opts))
+    }
   end
 
   defp actually_do_feed(feed_id_or_ids_or_name, filters, opts) do
@@ -922,6 +1338,41 @@ defmodule Bonfire.Social.FeedLoader do
         else: Feeds.my_home_feed_ids(opts)
 
     {home_feed_ids, opts}
+  end
+
+  def feed_ids_and_opts(:local = feed_name, opts) do
+    opts = Keyword.merge(local_feed_deferred_opts(opts), opts)
+
+    {named_feed_ids(feed_name, opts), opts}
+  end
+
+  defp local_feed_deferred_opts(opts) do
+    [
+      minimum_deferred_join_multiply_limit: local_minimum_deferred_join_multiply_limit(opts),
+      max_refill_deferred_join_multiply_limit: @local_max_refill_deferred_join_multiply_limit,
+      empty_refill_deferred_join_multiply_limit: @local_max_refill_deferred_join_multiply_limit,
+      underfilled_refill_deferred_join_multiply_limit:
+        @local_max_refill_deferred_join_multiply_limit,
+      deferred_inner_order: :feed_publish_id,
+      deferred_inner_guest_visible_acl_filter: guest_visible_first_page?(opts),
+      deferred_inner_boundary_filter: !cursor_pagination?(opts)
+    ]
+  end
+
+  defp guest_visible_first_page?(opts) do
+    guest_first_page?(opts) and guest_visible_acl_scope?()
+  end
+
+  defp guest_first_page?(opts) do
+    !cursor_pagination?(opts) and is_nil(current_user(opts)) and is_nil(current_account(opts))
+  end
+
+  defp local_minimum_deferred_join_multiply_limit(opts) do
+    if cursor_pagination?(opts) do
+      @local_max_refill_deferred_join_multiply_limit
+    else
+      @refill_deferred_join_multiply_limit
+    end
   end
 
   # def feed_ids_and_opts(:notifications = feed_name, opts) do
@@ -1047,14 +1498,22 @@ defmodule Bonfire.Social.FeedLoader do
     query
   end
 
-  defp make_distinct_by_activity_id(query, id, :asc, _opts)
+  defp make_distinct_by_activity_id(query, id, :asc, opts)
        when is_nil(id) or id == false or id == :id do
-    distinct(query, [activity: activity], asc: activity.id)
+    if opts[:deferred_inner_order] == :feed_publish_id do
+      distinct(query, [main_object: fp], asc: fp.id)
+    else
+      distinct(query, [activity: activity], asc: activity.id)
+    end
   end
 
-  defp make_distinct_by_activity_id(query, id, _desc, _opts)
+  defp make_distinct_by_activity_id(query, id, _desc, opts)
        when is_nil(id) or id == false or id == :id do
-    distinct(query, [activity: activity], desc: activity.id)
+    if opts[:deferred_inner_order] == :feed_publish_id do
+      distinct(query, [main_object: fp], desc: fp.id)
+    else
+      distinct(query, [activity: activity], desc: activity.id)
+    end
   end
 
   defp make_distinct_by_activity_id(query, other, :asc, opts) do
@@ -1194,9 +1653,17 @@ defmodule Bonfire.Social.FeedLoader do
       #       activity.subject_id == ^fetcher_user_id
       #   )
 
-      :local in specific_feed_ids or :activity_pub in specific_feed_ids or
-        federated_feed_id in specific_feed_ids or local_feed_id in specific_feed_ids ->
-        debug(feed_id_or_ids, "local or remote feed")
+      :local in specific_feed_ids or local_feed_id in specific_feed_ids ->
+        debug(feed_id_or_ids, "local feed")
+
+        query_extras(filters, opts)
+        |> where(
+          [fp, activity: activity],
+          fp.feed_id == ^local_feed_id and activity.subject_id != ^"1ACT1V1TYPVBREM0TESFETCHER"
+        )
+
+      :activity_pub in specific_feed_ids or federated_feed_id in specific_feed_ids ->
+        debug(feed_id_or_ids, "remote feed")
 
         query_extras(filters, opts)
 
@@ -1271,7 +1738,7 @@ defmodule Bonfire.Social.FeedLoader do
     # exclude_feed_ids = e(opts, :exclude_feed_ids, []) |> List.wrap() # WIP - to exclude activities that also appear in another feed
 
     (query || default_or_filtered_query(filters, FeedActivities.base_query(opts), opts))
-    |> reusable_join(:inner, [root], assoc(root, :activity), as: :activity)
+    |> join_activity_for_feed(opts)
     |> proload([:activity])
     |> query_optional_extras(filters, opts)
     |> maybe_filter(filters, opts)
@@ -1283,6 +1750,21 @@ defmodule Bonfire.Social.FeedLoader do
     # |> Activities.activity_preloads(e(opts, :preload, :with_object), opts) # if we want to preload the rest later to allow for caching
     # |> Activities.activity_preloads(opts[:preload], opts)
     # |> debug("post-preloads")
+  end
+
+  defp join_activity_for_feed(%Ecto.Query{aliases: %{activity: _}} = query, _opts), do: query
+
+  defp join_activity_for_feed(query, opts) do
+    if opts[:deferred_inner_order] == :feed_publish_id and cursor_pagination?(opts) do
+      # Keep the cursor window driven by feed_publish; otherwise Postgres may
+      # choose a merge join that walks activity_pkey through old local pages.
+      join(query, :inner, [root], activity in Activity,
+        on: activity.id == fragment("(?::text)::uuid", root.id),
+        as: :activity
+      )
+    else
+      reusable_join(query, :inner, [root], assoc(root, :activity), as: :activity)
+    end
   end
 
   @doc """

--- a/lib/runtime_config.ex
+++ b/lib/runtime_config.ex
@@ -57,7 +57,6 @@ defmodule Bonfire.Social.RuntimeConfig do
           description: l("Local instance activities"),
           filters: %FeedFilters{
             feed_name: :local,
-            origin: :local,
             exclude_activity_types: [:like, :follow, :request]
           },
           exclude_from_nav: false,

--- a/priv/repo/migrations/20260516000100_add_feed_publish_feed_id_id_index.exs
+++ b/priv/repo/migrations/20260516000100_add_feed_publish_feed_id_id_index.exs
@@ -1,0 +1,21 @@
+defmodule Bonfire.Social.Repo.Migrations.AddFeedPublishFeedIdIdIndex do
+  @moduledoc false
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    Bonfire.Data.Social.FeedPublish.Migration.add_feed_publish_feed_id_id_index(
+      concurrently: concurrently?()
+    )
+  end
+
+  def down do
+    Bonfire.Data.Social.FeedPublish.Migration.drop_feed_publish_feed_id_id_index(
+      concurrently: concurrently?()
+    )
+  end
+
+  defp concurrently?, do: System.get_env("DB_MIGRATE_INDEXES_CONCURRENTLY") != "false"
+end

--- a/priv/repo/migrations/20260516000200_add_activity_feed_lookup_index.exs
+++ b/priv/repo/migrations/20260516000200_add_activity_feed_lookup_index.exs
@@ -1,0 +1,21 @@
+defmodule Bonfire.Social.Repo.Migrations.AddActivityFeedLookupIndex do
+  @moduledoc false
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    Bonfire.Data.Social.Activity.Migration.add_activity_feed_lookup_index(
+      concurrently: concurrently?()
+    )
+  end
+
+  def down do
+    Bonfire.Data.Social.Activity.Migration.drop_activity_feed_lookup_index(
+      concurrently: concurrently?()
+    )
+  end
+
+  defp concurrently?, do: System.get_env("DB_MIGRATE_INDEXES_CONCURRENTLY") != "false"
+end

--- a/test/feeds/feed_query_pagination_test.exs
+++ b/test/feeds/feed_query_pagination_test.exs
@@ -2,15 +2,44 @@ defmodule Bonfire.Social.FeedPaginationTest do
   use Bonfire.Social.DataCase, async: true
   use Bonfire.Common.Utils
 
-  import Bonfire.Social.Fake
   import Bonfire.Posts.Fake
   import Ecto.Query
 
-  alias Bonfire.Social.FeedActivities
+  alias Bonfire.Boundaries.Acls
+  alias Bonfire.Boundaries.Grants
+  alias Bonfire.Data.Social.FeedPublish
   alias Bonfire.Social.FeedLoader
-  alias Bonfire.Social.Feeds
-  alias Bonfire.Posts
-  alias Needle.Pointer
+
+  defp activity_ids(edges), do: Enum.map(edges, & &1.activity.id)
+
+  defp publish_to_local_feed(post) do
+    {:ok, _published} =
+      repo().upsert(
+        Ecto.Changeset.cast(
+          %FeedPublish{},
+          %{feed_id: local_feed_id(), id: post.id},
+          [:feed_id, :id]
+        )
+      )
+
+    post
+  end
+
+  defp local_feed_id,
+    do: Bonfire.Boundaries.Circles.get_id(:local) || "3SERSFR0MY0VR10CA11NSTANCE"
+
+  defp with_pagination_hard_max_limit(limit) do
+    key = [:bonfire, :pagination_hard_max_limit]
+    previous = Process.get(key)
+
+    Process.put(key, limit)
+
+    on_exit(fn ->
+      if is_nil(previous),
+        do: Process.delete(key),
+        else: Process.put(key, previous)
+    end)
+  end
 
   test "return: :query returns an Ecto.Query struct" do
     # Get a query using the return: :query option
@@ -29,6 +58,127 @@ defmodule Bonfire.Social.FeedPaginationTest do
 
     # Should have ordering
     assert query_string =~ "order_by: [desc: a1.id]"
+    assert query_string =~ "f0.feed_id == ^\"3SERSFR0MY0VR10CA11NSTANCE\""
+    refute query_string =~ "is_nil(c5.id) or is_nil(p6.peer_id)"
+  end
+
+  test "deferred join load-more offset skips the effective first join window" do
+    with_pagination_hard_max_limit(1000)
+
+    limit = 20
+
+    query_string =
+      FeedLoader.feed(:local,
+        limit: limit,
+        query_with_deferred_join: true,
+        deferred_join_multiply_limit: 4,
+        return: :query,
+        preload: false
+      )
+      |> Inspect.Ecto.Query.to_string()
+
+    assert query_string =~ "limit: ^#{limit * 32 + 1}"
+    assert query_string =~ "limit: ^#{limit + 1}"
+    assert query_string =~ "offset: ^#{limit * 32}"
+    refute query_string =~ "offset: ^#{limit * 2}"
+
+    query_string =
+      FeedLoader.feed(:local,
+        limit: limit,
+        query_with_deferred_join: true,
+        deferred_join_multiply_limit: 8,
+        return: :query,
+        preload: false
+      )
+      |> Inspect.Ecto.Query.to_string()
+
+    assert query_string =~ "limit: ^#{limit * 32 + 1}"
+    assert query_string =~ "limit: ^#{limit + 1}"
+    assert query_string =~ "offset: ^#{limit * 32}"
+    refute query_string =~ "offset: ^#{limit * 2}"
+  end
+
+  test "local feed defaults to a wider deferred join window" do
+    with_pagination_hard_max_limit(1000)
+
+    limit = 20
+
+    query_string =
+      FeedLoader.feed(:local,
+        limit: limit,
+        query_with_deferred_join: true,
+        return: :query,
+        preload: false
+      )
+      |> Inspect.Ecto.Query.to_string()
+
+    assert query_string =~ "limit: ^#{limit * 32 + 1}"
+    assert query_string =~ "limit: ^#{limit + 1}"
+    refute query_string =~ "offset: ^#{limit * 16}"
+  end
+
+  test "anonymous local first page includes guest-visible custom ACLs" do
+    with_pagination_hard_max_limit(500)
+
+    limit = 1
+    user = fake_user!()
+    unique_tag = "guest_custom_acl_#{System.unique_integer([:positive])}"
+
+    custom_visible =
+      user
+      |> fake_post!("private", %{
+        post_content: %{
+          name: "Guest-visible custom ACL",
+          html_body: "Custom ACL content ##{unique_tag}"
+        }
+      })
+      |> publish_to_local_feed()
+
+    {:ok, acl} = Acls.get_or_create_object_custom_acl(custom_visible, user)
+    assert [_see, _read] = Grants.grant(:guest, acl, [:see, :read], true)
+
+    query_string =
+      FeedLoader.feed(:local,
+        limit: limit,
+        query_with_deferred_join: true,
+        return: :query,
+        preload: false
+      )
+      |> Inspect.Ecto.Query.to_string()
+
+    assert query_string =~ "Bonfire.Data.AccessControl.Grant"
+    assert query_string =~ "deferred_inner_guest_visible_acl"
+
+    feed =
+      FeedLoader.feed(:local, %{},
+        limit: limit,
+        query_with_deferred_join: true,
+        show_objects_only_once: false,
+        preload: false
+      )
+
+    assert length(feed.edges) == limit
+    assert FeedLoader.feed_contains?(feed.edges, custom_visible)
+  end
+
+  test "deferred join load-more offset uses nested pagination limit" do
+    with_pagination_hard_max_limit(1000)
+
+    limit = 20
+
+    query_string =
+      FeedLoader.feed(:local,
+        paginate: [limit: limit, return: :query],
+        query_with_deferred_join: true,
+        deferred_join_multiply_limit: 4,
+        return: :query,
+        preload: false
+      )
+      |> Inspect.Ecto.Query.to_string()
+
+    assert query_string =~ "limit: ^#{limit * 32 + 1}"
+    assert query_string =~ "offset: ^#{limit * 32}"
+    refute query_string =~ "offset: ^60"
   end
 
   describe "feed pagination with deferred join" do
@@ -65,10 +215,7 @@ defmodule Bonfire.Social.FeedPaginationTest do
       }
     end
 
-    test "works with default settings", %{
-      user: user,
-      posts: posts
-    } do
+    test "works with default settings", %{user: user} do
       # Get the first page of posts
       feed = FeedLoader.feed(:custom, %{}, current_user: user, limit: 5, preload: false)
 
@@ -162,6 +309,24 @@ defmodule Bonfire.Social.FeedPaginationTest do
       # TODO: The ID corresponding to the cursor value should be in the query
       # assert query2_string =~ after_cursor
 
+      expanded_window_query =
+        FeedLoader.feed(
+          :local,
+          opts ++
+            [
+              return: :query,
+              after: after_cursor,
+              deferred_join_multiply_limit: 4
+            ]
+        )
+
+      expanded_window_query_string = Inspect.Ecto.Query.to_string(expanded_window_query)
+
+      assert expanded_window_query_string =~ "where: (f0.id < ^\""
+      assert expanded_window_query_string =~ "limit: ^2561"
+      assert expanded_window_query_string =~ "offset: ^0"
+      refute expanded_window_query_string =~ "offset: ^20"
+
       # PART 4: Execute the second page query and verify results
       # -----------------------------------------------------
       assert %{edges: second_edges, page_info: _} =
@@ -207,33 +372,257 @@ defmodule Bonfire.Social.FeedPaginationTest do
       api_common_ids = MapSet.intersection(MapSet.new(api_first_ids), MapSet.new(api_second_ids))
       assert MapSet.size(api_common_ids) == 0, "Expected no overlap between API page 1 and page 2"
     end
-  end
 
-  #  NOTE: not sure if behaviour broken or test out of date?
-  @tag :todo
-  test "attempts pagination to next window before falling back to non-deferred query" do
-    limit = 4
-    user = fake_user!()
-    other_user = fake_user!()
-    default_join_multiply_limit = 2
+    test "nested paginator cursors expand the deferred join window without pre-offsetting", %{
+      user: user
+    } do
+      opts = [
+        current_user: user,
+        query_with_deferred_join: true,
+        limit: 5,
+        show_objects_only_once: false,
+        preload: false
+      ]
 
-    # Use a unique tag to ensure we control the results
-    unique_tag = "next_window_test"
+      first_page = FeedLoader.feed(:local, %{}, opts)
+      assert is_binary(first_page.page_info.end_cursor)
 
-    # Create posts with this tag that should appear in later windows
-    tagged_posts =
-      for i <- 1..limit do
+      nested_second_page =
+        FeedLoader.feed(
+          :local,
+          %{},
+          opts ++
+            [
+              paginate: [after: first_page.page_info.end_cursor, limit: 5],
+              deferred_join_multiply_limit: 4
+            ]
+        )
+
+      assert length(nested_second_page.edges) > 0
+
+      first_ids = Enum.map(first_page.edges, & &1.activity.id)
+      nested_second_ids = Enum.map(nested_second_page.edges, & &1.activity.id)
+      overlap = MapSet.intersection(MapSet.new(first_ids), MapSet.new(nested_second_ids))
+
+      assert MapSet.size(overlap) == 0,
+             "Expected nested paginator load-more pages not to overlap, got #{inspect(MapSet.to_list(overlap))}"
+
+      nested_after_query =
+        FeedLoader.feed(
+          :local,
+          %{},
+          opts ++
+            [
+              return: :query,
+              paginate: [after: first_page.page_info.end_cursor, limit: 5, return: :query],
+              deferred_join_multiply_limit: 4
+            ]
+        )
+
+      nested_after_query_string = Inspect.Ecto.Query.to_string(nested_after_query)
+
+      assert nested_after_query_string =~ "where:"
+      assert nested_after_query_string =~ "limit: ^2561"
+      assert nested_after_query_string =~ "offset: ^0"
+      refute nested_after_query_string =~ "offset: ^20"
+    end
+
+    test "paginate false still disables pagination" do
+      user = fake_user!()
+      unique_tag = "paginate_false_#{System.unique_integer([:positive])}"
+
+      for i <- 1..5 do
         fake_post!(user, "public", %{
           post_content: %{
-            name: "Next Window Test #{i}",
-            # Adding the tag in content
-            html_body: "Content with ##{unique_tag}"
+            name: "Paginate False #{i}",
+            html_body: "Paginate false visible content #{i} ##{unique_tag}"
           }
         })
       end
 
+      result =
+        FeedLoader.feed(:custom, %{tags: [unique_tag]},
+          current_user: user,
+          query_with_deferred_join: false,
+          paginate: false,
+          limit: 1,
+          show_objects_only_once: false,
+          preload: false
+        )
+
+      assert is_list(result)
+      assert length(result) >= 5
+    end
+  end
+
+  test "cursor load-more skips a boundary-hidden deferred join window" do
+    with_pagination_hard_max_limit(500)
+
+    limit = 3
+    user = fake_user!()
+    other_user = fake_user!()
+    unique_tag = "cursor_gap_#{System.unique_integer([:positive])}"
+
+    older_public =
+      for i <- 1..limit do
+        fake_post!(user, "public", %{
+          post_content: %{
+            name: "Older Gap Public #{i}",
+            html_body: "Older visible content ##{unique_tag}"
+          }
+        })
+      end
+
+    hidden_private =
+      for i <- 1..(limit * 6 + 1) do
+        fake_post!(other_user, "mentions", %{
+          post_content: %{
+            name: "Hidden Gap Private #{i}",
+            html_body: "Boundary hidden content ##{unique_tag}"
+          }
+        })
+      end
+
+    Enum.each(hidden_private, &publish_to_local_feed/1)
+
+    newer_public =
+      for i <- 1..limit do
+        fake_post!(user, "public", %{
+          post_content: %{
+            name: "Newer Gap Public #{i}",
+            html_body: "Newer visible content ##{unique_tag}"
+          }
+        })
+      end
+
+    opts = [
+      current_user: user,
+      limit: limit,
+      query_with_deferred_join: true,
+      show_objects_only_once: false,
+      preload: false
+    ]
+
+    first_page = FeedLoader.feed(:local, %{}, opts)
+    assert length(first_page.edges) == limit
+    assert Enum.all?(newer_public, &FeedLoader.feed_contains?(first_page.edges, &1))
+    refute Enum.any?(hidden_private, &FeedLoader.feed_contains?(first_page.edges, &1))
+    assert is_binary(first_page.page_info.end_cursor)
+
+    second_page =
+      FeedLoader.feed(:local, %{}, opts ++ [after: first_page.page_info.end_cursor])
+
+    assert length(second_page.edges) == limit
+    assert Enum.all?(older_public, &FeedLoader.feed_contains?(second_page.edges, &1))
+    refute Enum.any?(hidden_private, &FeedLoader.feed_contains?(second_page.edges, &1))
+
+    first_ids = Enum.map(first_page.edges, & &1.activity.id)
+    second_ids = Enum.map(second_page.edges, & &1.activity.id)
+    overlap = MapSet.intersection(MapSet.new(first_ids), MapSet.new(second_ids))
+
+    assert MapSet.size(overlap) == 0,
+           "Expected cursor load-more pages not to overlap, got #{inspect(MapSet.to_list(overlap))}"
+  end
+
+  test "top-level cursor survives nested paginate limit across multiple hidden windows" do
+    with_pagination_hard_max_limit(500)
+
+    limit = 3
+    user = fake_user!()
+    other_user = fake_user!()
+    unique_tag = "mixed_cursor_gap_#{System.unique_integer([:positive])}"
+
+    older_public =
+      for i <- 1..limit do
+        fake_post!(user, "public", %{
+          post_content: %{
+            name: "Older Mixed Public #{i}",
+            html_body: "Older mixed visible content ##{unique_tag}"
+          }
+        })
+      end
+
+    hidden_private =
+      for i <- 1..(limit * 20) do
+        fake_post!(other_user, "mentions", %{
+          post_content: %{
+            name: "Hidden Mixed Private #{i}",
+            html_body: "Boundary hidden mixed content ##{unique_tag}"
+          }
+        })
+      end
+
+    newer_public =
+      for i <- 1..limit do
+        fake_post!(user, "public", %{
+          post_content: %{
+            name: "Newer Mixed Public #{i}",
+            html_body: "Newer mixed visible content ##{unique_tag}"
+          }
+        })
+      end
+
+    opts = [
+      current_user: user,
+      query_with_deferred_join: true,
+      show_objects_only_once: false,
+      preload: false
+    ]
+
+    first_page = FeedLoader.feed(:local, %{}, opts ++ [paginate: [limit: limit]])
+    assert length(first_page.edges) == limit
+    assert Enum.all?(newer_public, &FeedLoader.feed_contains?(first_page.edges, &1))
+
+    second_page =
+      FeedLoader.feed(
+        :local,
+        %{},
+        opts ++
+          [
+            after: first_page.page_info.end_cursor,
+            paginate: [limit: limit],
+            deferred_join_multiply_limit: 4
+          ]
+      )
+
+    assert length(second_page.edges) == limit
+    assert Enum.all?(older_public, &FeedLoader.feed_contains?(second_page.edges, &1))
+    refute Enum.any?(hidden_private, &FeedLoader.feed_contains?(second_page.edges, &1))
+
+    overlap =
+      MapSet.intersection(
+        MapSet.new(activity_ids(first_page.edges)),
+        MapSet.new(activity_ids(second_page.edges))
+      )
+
+    assert MapSet.size(overlap) == 0,
+           "Expected mixed cursor/nested paginate pages not to overlap, got #{inspect(MapSet.to_list(overlap))}"
+  end
+
+  test "attempts pagination to next window before falling back to non-deferred query" do
+    with_pagination_hard_max_limit(500)
+
+    limit = 2
+    user = fake_user!()
+    other_user = fake_user!()
+    initial_deferred_join_multiply_limit = 6
+
+    # Use a unique tag to ensure we control the results
+    unique_tag = "next_window_test_#{System.unique_integer([:positive])}"
+
+    # Create posts with this tag that should appear in later windows
+    for i <- 1..limit do
+      fake_post!(user, "public", %{
+        post_content: %{
+          name: "Next Window Test #{i}",
+          # Adding the tag in content
+          html_body: "Content with ##{unique_tag}"
+        }
+      })
+    end
+
     # Create (more recent) posts that would appear in the first window but won't be included by boundaries
-    for i <- 1..(limit * 2 + 1) do
+    for i <- 1..(limit * initial_deferred_join_multiply_limit + 1) do
       fake_post!(other_user, "mentions", %{
         post_content: %{
           name: "First Window Test #{i}",
@@ -274,7 +663,7 @@ defmodule Bonfire.Social.FeedPaginationTest do
              )
 
     # Will be empty because our tagged posts are not in first window
-    refute FeedLoader.feed_contains?(edges, "next_window_test")
+    refute FeedLoader.feed_contains?(edges, unique_tag)
     refute FeedLoader.feed_contains?(edges, "First Window Test")
     assert edges == []
 
@@ -301,13 +690,13 @@ defmodule Bonfire.Social.FeedPaginationTest do
     assert next_query_string =~ " in subquery(from"
 
     # Should offset limit but NOT have cursor-based filtering
-    assert next_query_string =~ "offset: ^#{default_join_multiply_limit * limit}"
-    refute next_query_string =~ "where: (a1.id < ^"
+    assert next_query_string =~ "offset: ^#{initial_deferred_join_multiply_limit * limit}"
+    refute next_query_string =~ "where: (f0.id < ^"
 
-    # Should have larger limit (multiply_limit: 3)
+    # Should have a larger limit, clamped to the minimum deferred join window.
     # The limit parameter will be bound
     assert next_query_string =~
-             "limit: ^#{limit * deferred_join_multiply_limit + 1}"
+             "limit: ^#{limit * initial_deferred_join_multiply_limit + 1}"
 
     # but not in outer query
     assert next_query_string =~ "limit: ^#{limit + 1}"
@@ -319,7 +708,7 @@ defmodule Bonfire.Social.FeedPaginationTest do
         limit: limit,
         after: next_cursor,
         query_with_deferred_join: true,
-        deferred_join_multiply_limit: 3,
+        deferred_join_multiply_limit: deferred_join_multiply_limit,
         #  to avoid deduping messing with the count
         show_objects_only_once: false,
         preload: false
@@ -327,7 +716,7 @@ defmodule Bonfire.Social.FeedPaginationTest do
 
     assert %{edges: next_edges} = next_window_results
     assert length(next_edges) > 0
-    assert FeedLoader.feed_contains?(next_edges, "next_window_test")
+    assert FeedLoader.feed_contains?(next_edges, unique_tag)
 
     # Execute a normal query - should also find our tagged posts using the high-level API which automatically attempts to load next window or removed the deferred join if nothing is found the 2nd time
     automatic_next_window_results =
@@ -342,15 +731,119 @@ defmodule Bonfire.Social.FeedPaginationTest do
         preload: false
       )
 
-    assert %{edges: next_edges} = next_window_results
-    assert length(next_edges) > 0
-    assert FeedLoader.feed_contains?(next_edges, "next_window_test")
+    assert %{edges: automatic_next_edges} = automatic_next_window_results
+    assert length(automatic_next_edges) > 0
+    assert FeedLoader.feed_contains?(automatic_next_edges, unique_tag)
+  end
+
+  test "refills an under-filled deferred join page before returning it" do
+    with_pagination_hard_max_limit(500)
+
+    limit = 4
+    user = fake_user!()
+    other_user = fake_user!()
+    unique_tag = "underfilled_window_test_#{System.unique_integer([:positive])}"
+
+    older_public =
+      for i <- 1..limit do
+        fake_post!(user, "public", %{
+          post_content: %{
+            name: "Older visible refill #{i}",
+            html_body: "Older visible refill ##{unique_tag}"
+          }
+        })
+      end
+
+    for i <- 1..(limit * 6 - 2) do
+      fake_post!(other_user, "mentions", %{
+        post_content: %{
+          name: "Hidden first-window #{i}",
+          html_body: "Hidden first-window content"
+        }
+      })
+    end
+
+    for i <- 1..2 do
+      fake_post!(user, "public", %{
+        post_content: %{
+          name: "Newest visible partial #{i}",
+          html_body: "Newest visible partial ##{unique_tag}"
+        }
+      })
+    end
+
+    %{edges: edges} =
+      FeedLoader.feed(:explore, %{},
+        current_user: user,
+        limit: limit,
+        query_with_deferred_join: true,
+        show_objects_only_once: false,
+        preload: false
+      )
+
+    assert length(edges) == limit
+    assert Enum.any?(older_public, &FeedLoader.feed_contains?(edges, &1))
+    refute FeedLoader.feed_contains?(edges, "Hidden first-window")
+  end
+
+  test "refills across a larger hidden deferred window before returning visible rows" do
+    with_pagination_hard_max_limit(500)
+
+    limit = 4
+    user = fake_user!()
+    other_user = fake_user!()
+    unique_tag = "adaptive_refill_test_#{System.unique_integer([:positive])}"
+
+    older_public =
+      for i <- 1..limit do
+        fake_post!(user, "public", %{
+          post_content: %{
+            name: "Older adaptive refill #{i}",
+            html_body: "Older adaptive refill ##{unique_tag}"
+          }
+        })
+      end
+
+    hidden_rows = limit * 16 + 2
+
+    for i <- 1..hidden_rows do
+      fake_post!(other_user, "mentions", %{
+        post_content: %{
+          name: "Hidden adaptive-window #{i}",
+          html_body: "Hidden adaptive-window content"
+        }
+      })
+    end
+
+    for i <- 1..1 do
+      fake_post!(user, "public", %{
+        post_content: %{
+          name: "Newest adaptive partial #{i}",
+          html_body: "Newest adaptive partial ##{unique_tag}"
+        }
+      })
+    end
+
+    %{edges: edges} =
+      FeedLoader.feed(:explore, %{},
+        current_user: user,
+        limit: limit,
+        query_with_deferred_join: true,
+        show_objects_only_once: false,
+        preload: false
+      )
+
+    assert length(edges) == limit
+    assert Enum.any?(older_public, &FeedLoader.feed_contains?(edges, &1))
+    assert FeedLoader.feed_contains?(edges, unique_tag)
+    refute FeedLoader.feed_contains?(edges, "Hidden adaptive-window")
   end
 
   describe "reply_count sorting with exclude_activity_types: [:reply]" do
     setup do
       user = fake_user!("reply_sort_tester")
       replier = fake_user!("replier")
+      unique_tag = "reply_sort_#{System.unique_integer([:positive])}"
 
       # Create 12 root posts (more than one page of 5)
       posts =
@@ -358,7 +851,7 @@ defmodule Bonfire.Social.FeedPaginationTest do
           fake_post!(user, "public", %{
             post_content: %{
               name: "Discussion #{i}",
-              html_body: "Content for discussion #{i}"
+              html_body: "Content for discussion #{i} ##{unique_tag}"
             }
           })
         end
@@ -374,10 +867,10 @@ defmodule Bonfire.Social.FeedPaginationTest do
         end
       end
 
-      %{user: user, posts: posts}
+      %{user: user, posts: posts, unique_tag: unique_tag}
     end
 
-    test "pagination has no overlap between pages", %{user: user} do
+    test "pagination has no overlap between pages", %{user: user, unique_tag: unique_tag} do
       opts = [
         current_user: user,
         limit: 5,
@@ -388,7 +881,8 @@ defmodule Bonfire.Social.FeedPaginationTest do
       filters = %{
         sort_by: :reply_count,
         sort_order: :desc,
-        exclude_activity_types: [:reply]
+        exclude_activity_types: [:reply],
+        tags: [unique_tag]
       }
 
       # First page
@@ -411,7 +905,7 @@ defmodule Bonfire.Social.FeedPaginationTest do
              "Pages overlap on IDs: #{inspect(MapSet.to_list(overlap))}"
     end
 
-    test "pagination returns all items across pages", %{user: user} do
+    test "pagination returns all items across pages", %{user: user, unique_tag: unique_tag} do
       opts = [
         current_user: user,
         limit: 5,
@@ -422,7 +916,8 @@ defmodule Bonfire.Social.FeedPaginationTest do
       filters = %{
         sort_by: :reply_count,
         sort_order: :desc,
-        exclude_activity_types: [:reply]
+        exclude_activity_types: [:reply],
+        tags: [unique_tag]
       }
 
       all_ids =


### PR DESCRIPTION
## Summary

Part 3 of the Bonfire feed query performance stack for bonfire-networks/bounties#1.

This bounds local feed pagination while preserving boundary semantics:

- Add migrations for the feed publish and activity lookup indexes.
- Use a deferred inner query for local feed pagination.
- Order inner candidates by feed publish id so scans stay bounded.
- Preserve guest-visible custom ACL rows instead of using a `public` shortcut.
- Keep fallback telemetry for non-deferred cases.
- Extend feed pagination regression coverage.

## Stack

1. bonfire_common: https://github.com/bonfire-networks/bonfire_common/pull/15
2. bonfire_data_social: https://github.com/bonfire-networks/bonfire_data_social/pull/5
3. bonfire_social: https://github.com/bonfire-networks/bonfire_social/pull/7
4. bonfire_ui_social: https://github.com/bonfire-networks/bonfire_ui_social/pull/9
5. bonfire-app: https://github.com/bonfire-networks/bonfire-app/pull/1994

## Why

The bounty target is the Classic guest local feed query for a page of 20 activities with no time filter. The slow path comes from doing too much work before the candidate window is bounded. This keeps the semantic outer query path while making the inner candidate scan predictable.

This is not a local-feed cache workaround and does not bypass boundaries with a `public` boolean.

## Validation

Stack-level validation was run from `bonfire-app` after applying the sibling branches:

```bash
BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER=128 BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS=25 ./test-pagination-regression.sh all-with-strict-benchmark
```

Result: passed locally in about 15.2 minutes.

Key local benchmark results:

- Classic sparse stress, 1,000,000 rows: `cold_first_timing_ms=48.98`, `page_max_ms=97.14`, `page_p95_ms=91.5`.
- All-local heavy, 1,000,000 rows: `cold_first_timing_ms=30.04`, `page_max_ms=17.56`, `page_p95_ms=14.64`.
- Guest-visible ACL stress, 1,000,000 rows: `cold_first_timing_ms=48.93`, `page_max_ms=43.68`, `page_p95_ms=40.99`.
- Backend regression block: `17 tests, 0 failures (1 excluded)`.

Additional local check:

- `git diff --check origin/main..HEAD`

## Known Limits

I do not have the campground database or maintainer hardware, so I am not claiming the official `feed_backend` benchmark has passed. That still needs maintainer verification on campground.
